### PR TITLE
Include c3dc data model in the multi model validator

### DIFF
--- a/src/commons/literals.py
+++ b/src/commons/literals.py
@@ -57,3 +57,4 @@ class CommonsFeat:
     )
     ccdi: dict = field(default_factory=lambda: {"delimiter": ";"})
     cds: dict = field(default_factory=lambda: {"delimiter": "|"})
+    c3dc: dict = field(default_factory=lambda: {"delimiter": ";"})

--- a/src/commons/literals.py
+++ b/src/commons/literals.py
@@ -38,6 +38,15 @@ class CommonsRepo:
             "master_zipball": "https://github.com/CBIIT/cds-model/archive/refs/heads/main.zip",
         }
     )
+    c3dc: dict = field(
+        default_factory=lambda: {
+            "repo": "https://github.com/CBIIT/c3dc-model",
+            "model_yaml": "model-desc/c3dc-model.yml",
+            "props_yaml": "model-desc/c3dc-model-props.yml",
+            "tags_api": "https://api.github.com/repos/CBIIT/c3dc-model/tags",
+            "master_zipball": "https://github.com/CBIIT/c3dc-model/archive/refs/heads/main.zip",
+        }
+    )
 
 @dataclass
 class CommonsFeat:

--- a/workflow/validate_submission.py
+++ b/workflow/validate_submission.py
@@ -2,8 +2,10 @@ from src.commons.submval import SubmVal
 from src.commons.datamodel import ReadDataModel, GetDataModel
 from src.commons.utils import AwsUtils, get_date, get_time
 from prefect import get_run_logger, flow, task
+from typing import Literal
 import os
 
+DropDownChoices = Literal["ccdi", "icdc", "cds", "c3dc"]
 
 @task(name="Validate Required Properties", log_prints=True)
 def val_required(valid_object: SubmVal, datamodel_obj: ReadDataModel) -> str:
@@ -116,15 +118,15 @@ def write_report(
 
 
 @flow(name="Validate Submission Files", log_prints=True)
-def validate_submission_tsv(submission_loc: str, commons_name: str, val_output_bucket: str, runner: str, tag: str = "", exclude_node_type: list[str] = []) -> None:  
+def validate_submission_tsv(submission_loc: str, commons_name: DropDownChoices, val_output_bucket: str, runner: str, tag: str = "", exclude_node_type: list[str] = []) -> None:  
     """Prefect flow which validates a folder of submission tsv files against data model
 
     Args:
         submission_loc (str): Bucket location of submission files (tsv). Whitespace is NOT allowed, e.g., s3://bucket-name/folder-path
-        commons_name (str): Commons acronym. Acceptable options are: ccdi, icdc, cds, c3dc
+        commons_name (DropDownChoices): Commons acronym. Acceptable options are: ccdi, icdc, cds, c3dc
         val_output_bucket (str): Bucket name of where validation output be uploaded to
         runner (str): Unique runner name without whitespace, e.g., john_smith
-        tag (str, optional): Tag name of the data model. Defaults to "" to use master branch. 
+        tag (str, optional): Tag name of the data model. Defaults to "" to use master branch.
         exclude_node_type (list[str], optional): List of nodes to exclude. Defaults to [].
     """
     logger = get_run_logger()
@@ -157,13 +159,16 @@ def validate_submission_tsv(submission_loc: str, commons_name: str, val_output_b
 
     return None
 
+
 @flow(name="Validate Data Model", log_prints=True)
-def validate_data_model(commons_name: str, val_output_bucket: str, runner: str, tag: str = "") -> None:
+def validate_data_model(
+    commons_name: DropDownChoices, val_output_bucket: str, runner: str, tag: str = ""
+) -> None:
     """Prefect flow that generates a table of data model props (tsv) which can be used for
     submssion file validation
 
     Args:
-        commons_name (str): Commons acronym. Acceptable options are: ccdi, icdc, cds, c3dc
+        commons_name (DropDownChoices): Commons acronym. Acceptable options are: ccdi, icdc, cds, c3dc
         val_output_bucket (str): Bucket name of where the output be uploaded to
         runner (str): Unique runner name without whitespace, e.g., john_smith
         tag (str, optional): Tag name of the data model. Defaults to "" to use master branch.

--- a/workflow/validate_submission.py
+++ b/workflow/validate_submission.py
@@ -121,7 +121,7 @@ def validate_submission_tsv(submission_loc: str, commons_name: str, val_output_b
 
     Args:
         submission_loc (str): Bucket location of submission files (tsv). Whitespace is NOT allowed, e.g., s3://bucket-name/folder-path
-        commons_name (str): Commons acronym. Acceptable options are: ccdi, icdc
+        commons_name (str): Commons acronym. Acceptable options are: ccdi, icdc, cds, c3dc
         val_output_bucket (str): Bucket name of where validation output be uploaded to
         runner (str): Unique runner name without whitespace, e.g., john_smith
         tag (str, optional): Tag name of the data model. Defaults to "" to use master branch. 
@@ -163,7 +163,7 @@ def validate_data_model(commons_name: str, val_output_bucket: str, runner: str, 
     submssion file validation
 
     Args:
-        commons_name (str): Commons acronym. Acceptable options are: ccdi, icdc, cds
+        commons_name (str): Commons acronym. Acceptable options are: ccdi, icdc, cds, c3dc
         val_output_bucket (str): Bucket name of where the output be uploaded to
         runner (str): Unique runner name without whitespace, e.g., john_smith
         tag (str, optional): Tag name of the data model. Defaults to "" to use master branch.


### PR DESCRIPTION
Added patch

- Allows c3dc data model as an input option for the multi-model validator
- Added repo and feature information of C3DC to the workflow