### PR TITLE
Fix sampel query

### DIFF
--- a/src/crdcdh/dh_mongodb.py
+++ b/src/crdcdh/dh_mongodb.py
@@ -300,6 +300,7 @@ class DataHubMongoDB(CrdcDHMongoSecrets):
             )
             # we assume this submission id is only associated with one study
             sample_dict = dict()
+            uncheckable_sample_list = []
             if (
                 record_collection.count_documents(
                     {"submissionID": submission_id, "nodeType": "sample"}
@@ -307,24 +308,38 @@ class DataHubMongoDB(CrdcDHMongoSecrets):
                 > 0
             ):
                 for item in query_return_list:
+                    # item["parents"] is a list, we have situations when a sample is lack of linkage to a participant node, or a sample is linked to multiple types of nodes.
                     item_id = item["props"]["sample_id"]
-                    item_parent = item["parents"][0]["parentIDValue"]
-                    item_parent_query_response = record_collection.find(
-                        {
-                            "submissionID": submission_id,
-                            "nodeType": "participant",
-                            "nodeID": item_parent,
-                        }
-                    )
-                    # we only expect one participant return in this case because one sample is most likely
-                    # pointing to one participant instead of multiple
-                    item_parent_id = item_parent_query_response[0]["props"][
-                        "participant_id"
-                    ]
-                    sample_dict[item_id] = item_parent_id
+                    item_parent_list = item["parents"]
+                    item_has_participant_parent = False
+                    for parent in item_parent_list:
+                        if parent["parentType"] == "participant":
+                            item_has_participant_parent = True
+                            item_parent_query_response = record_collection.find(
+                                {
+                                    "submissionID": submission_id,
+                                    "nodeType": "participant",
+                                    "nodeID": parent["parentIDValue"], # in GC, this is the value of study_participant_id property. In CCDI-DCC, this matches to participant_id property
+                                }
+                            )
+
+                            # now query for "participant_id" value for the participant matched
+                            # this is because in GC, parentID value return the value of study_participant_id prop. Participant node also has a participant_id prop, which is the value submitted to dbGaP
+                            # However in CCDI-DCC, parentIDValue should match participant_id prop under participant node
+                            item_parent_id = item_parent_query_response[0]["props"][
+                                "participant_id"
+                            ]
+                            sample_dict[item_id] = item_parent_id
+                            break
+                        else:
+                            pass
+                    if not item_has_participant_parent:
+                        uncheckable_sample_list.append(item_id)
+                    else:
+                        pass
             else:
                 pass
-            return sample_dict
+            return uncheckable_sample_list, sample_dict
         except errors.PyMongoError as pe:
             print(
                 f"Failed to query sample_id in dataRecords collection with submissionID: {submission_id}\nPyMongoError: {repr(pe)}"

--- a/workflow/crdcdh/dbgap_validation.py
+++ b/workflow/crdcdh/dbgap_validation.py
@@ -20,6 +20,7 @@ def dbgap_validation_md(
     study_version: str,
     participant_count: int,
     sample_count: int,
+    uncheckable_sample_list: list[str],
     validationstr: str,
 ) -> None:
     """Creates an artifact of metadata validation flow
@@ -35,6 +36,12 @@ def dbgap_validation_md(
         study_version = "Not Found [WARNING: Validation was performed using LATEST version found through dbGaP API]"
     else:
         pass
+    if len(uncheckable_sample_list) > 0:
+        uncheckable_sample_count = len(uncheckable_sample_list)
+        uncheckable_sample_df_str = pd.DataFrame(uncheckable_sample_list, columns=["Sample ID"]).to_markdown(tablefmt="pipe", index=False)
+    else:
+        uncheckable_sample_count = 0
+        uncheckable_sample_df_str = ""
     markdown_report = f"""# CRDCDH Metadata Validation Report - {get_time()}
 ## Submission Information
 
@@ -50,8 +57,12 @@ def dbgap_validation_md(
 - **Participant count in DB**
     - {participant_count}
 
-- **Sample count in DB**
+- **Sample count in DB that are linked to participants**
     - {sample_count}
+
+- **Sample in DB CANNOT be checked for dbGaP validation**
+    - {uncheckable_sample_count}
+{uncheckable_sample_df_str}
 
 ## Validation Report
 
@@ -420,13 +431,20 @@ def validation_against_dbgap(submission_id: str, tier: TierDropDownChoices, chec
     submission_participants = db_object.get_study_participants(
         submission_id=submission_id
     )
-    submission_samples = db_object.get_study_samples(submission_id=submission_id)
+    uncheckable_samples, submission_samples = db_object.get_study_samples(submission_id=submission_id)
+    total_samples = len(uncheckable_samples) + len(submission_samples.keys())
     logger.info(
         f"Participants found in submission {submission_id}: {len(submission_participants)}"
     )
     logger.info(
-        f"Samples found in submission {submission_id}: {len(submission_samples.keys())}"
+        f"Samples found in submission {submission_id}: {total_samples}"
     )
+    if len(uncheckable_samples) > 0:
+        logger.warning(
+            f"Found {len(uncheckable_samples)} out of {total_samples} sample(s) in submission {submission_id} that cannot be checked for dbGaP validation because they are either not linked to any participant. These samples will be skipped for dbGaP validation."
+        )
+    else:
+        logger.info("All samples in this submission can be checked for dbGaP validation because we found every sample linked to a participant node.")
 
     # get dbgap accession and version in DB
     study_accession = db_object.get_dbgap_id(submission_id=submission_id)
@@ -484,6 +502,7 @@ def validation_against_dbgap(submission_id: str, tier: TierDropDownChoices, chec
         study_version=study_version,
         participant_count=len(submission_participants),
         sample_count=len(submission_samples.keys()),
+        uncheckable_sample_list=uncheckable_samples,
         validationstr=validation_str,
     )
     return None


### PR DESCRIPTION
Added fix

- Find participants in the upper level of pdx samples in GC submisison
- Report any participant/sample in DB but not found in dbGaP as ERROR. Give WARNING to any participant/sample in dbGaP that are not found in DB